### PR TITLE
Small fixes

### DIFF
--- a/.i3/config
+++ b/.i3/config
@@ -161,7 +161,7 @@ bindsym $mod+c exec chromium
 bindsym $mod+t exec subl
 bindsym $mod+y exec atom
 bindsym $mod+Shift+s exec --no-startup-id "i3lock && systemctl suspend"
-bindsym $mod+Shift+x exec --no-startup-id "gnome-screenshot -f tmp/fakeD.png && convert tmp/fakeD.png -channel RGBA -blur 0x4 tmp/fakeD.png  &&  i3lock -i tmp/fakeD.png -n"
+bindsym $mod+Shift+x exec --no-startup-id "gnome-screenshot -f /tmp/fakeD.png && convert /tmp/fakeD.png -channel RGBA -blur 0x4 /tmp/fakeD.png  &&  i3lock -i /tmp/fakeD.png -n"
 bindsym $mod+F9 exec amixer -q set Master toggle
 bindsym $mod+F10 exec amixer -q set Master 7%- unmute
 bindsym $mod+F11 exec amixer -q set Master 7%+ unmute

--- a/.i3/config
+++ b/.i3/config
@@ -163,14 +163,14 @@ bindsym $mod+y exec atom
 bindsym $mod+Shift+s exec --no-startup-id "i3lock && systemctl suspend"
 bindsym $mod+Shift+x exec --no-startup-id "i3lock"
 bindsym $mod+F9 exec amixer -q set Master toggle
-bindsym $mod+F10 exec amixer -q set Master 1%- unmute
-bindsym $mod+F11 exec amixer -q set Master 1%+ unmute
+bindsym $mod+F10 exec amixer -q set Master 7%- unmute
+bindsym $mod+F11 exec amixer -q set Master 7%+ unmute
 
-bindsym XF86AudioLowerVolume exec amixer -q set Master 1%- unmute
-bindsym XF86AudioRaiseVolume exec amixer -q set Master 1%+ unmute
+bindsym XF86AudioLowerVolume exec amixer -q set Master 7%- unmute
+bindsym XF86AudioRaiseVolume exec amixer -q set Master 7%+ unmute
 bindsym XF86AudioMute exec amixer -q set Master toggle
 
-bindsym XF86MonBrightnessUp exec xbacklight -inc 10
-bindsym XF86MonBrightnessDown exec xbacklight -dec 10
+bindsym XF86MonBrightnessUp exec xbacklight -inc 15
+bindsym XF86MonBrightnessDown exec xbacklight -dec 15
 
 exec --no-startup-id nm-applet


### PR DESCRIPTION
Prevent your multimedia hotkeys from breaking.
Use absolute path for screenshot image.
